### PR TITLE
EX-1548 Sumsub callback zone labelling/routing

### DIFF
--- a/edgebus-setup.toml
+++ b/edgebus-setup.toml
@@ -14,6 +14,10 @@
 	name = "sumsub"
 	description = "Sumsub's callbacks"
 	mediaType = "application/json"
+	[[edgebus.setup.topic.labelHandler]]
+		index = "LBHD551765cce2e84f82bf4393a1c267fdfe"
+		kind = "EXTERNAL_PROCESS"
+		path="label_handlers/ext_handler.sh"
 # /Setup topic "TOPCcdaa9b7d6c16484bb2a5a6d58c78c2c6"
 
 # Setup topic "TOPC44e5b80b06f1447ebf38b6ab2c84c84a"


### PR DESCRIPTION
…code.

Refactor database migration

#6 Messages labeling

EX-1514 First implemetation

EX-1514 Fix after rebase

EX-1514 Fix after review

Trying to make unique instance of API Identifier using WeakRef.

Expose message labels at Bull Queues layer. Cleanup code.

Expose message labels at WebSocket host egress. Cleanup code.

Extract ck__tb_egress_delivery__evidence and uq__tb_egress_delivery__success into separate files (to be able to symlink in future db versions)

EX-1551 Fix label handlers execute

EX-1548 Moved label binding in creation message method

EX-1548 Add timeout to external process executer

EX-1548 Fix after review

EX-1548 Move external process runnig to standalone class

EX-1548 Add own Exceptions for ExternalProcess class

EX-1548 Change label handlers path